### PR TITLE
Fix edge routing for child/grouped nodes

### DIFF
--- a/src/layout/edge/index.ts
+++ b/src/layout/edge/index.ts
@@ -40,14 +40,12 @@ export function getBasePath({
       position: targetPosition,
     },
     sourceRect: {
-      x: sourceNode.position.x,
-      y: sourceNode.position.y,
+      ...(sourceNode.positionAbsolute || sourceNode.position),
       width: sourceNode.width!,
       height: sourceNode.height!,
     },
     targetRect: {
-      x: targetNode.position.x,
-      y: targetNode.position.y,
+      ...(targetNode.positionAbsolute || targetNode.position),
       width: targetNode.width!,
       height: targetNode.height!,
     },


### PR DESCRIPTION
Edge-routing to child/grouped nodes (i.e. nodes with a parent node) seemed to be offset - I believe this is because reactflow sets child node `position`s to relative values to their parent node. This change uses the `positionAbsolute` if it's defined (e.g. for child nodes), otherwise it uses `position` (e.g. for nodes without parents).